### PR TITLE
Fix Dragging + Dropping in Editor

### DIFF
--- a/Editor/TextTween.Editor.asmdef
+++ b/Editor/TextTween.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "TextTween.Editor",
     "rootNamespace": "TextTween",
     "references": [
-        "GUID:999262d7d7e04288bc6aebef915dc2b8"
+        "GUID:999262d7d7e04288bc6aebef915dc2b8",
+        "GUID:6055be8ebefd69e48b49212b09b47b2f"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/TextTweenEditor.cs
+++ b/Editor/TextTweenEditor.cs
@@ -1,58 +1,70 @@
-using UnityEditor;
-
 namespace TextTween.Editor {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using TMPro;
+    using UnityEditor;
+
     [CustomEditor(typeof(TweenManager))]
-    public class TextTweenEditor : UnityEditor.Editor {
-        private TweenManager _tweenManager;
-        
-        private SerializedProperty _progressProperty;
-        private SerializedProperty _offsetProperty;
-        private SerializedProperty _textsProperty;
-        private SerializedProperty _modifiersProperty;
-        
+    public class TextTweenEditor : Editor {
+        private float _progress;
+        private float _offset;
+        private readonly List<TMP_Text> _texts = new();
+        private readonly List<CharModifier> _modifiers = new();
+
+        private static readonly Lazy<FieldInfo> TextField = new(() => typeof(TweenManager).GetField("_texts", 
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+
+        private static readonly Lazy<FieldInfo> ModifiersField = new(() => typeof(TweenManager).GetField("_modifiers", 
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+
         private void OnEnable() {
-            _tweenManager = (TweenManager) target;
-            
-            _progressProperty = serializedObject.FindProperty("Progress");
-            _offsetProperty = serializedObject.FindProperty("Offset");
-            _textsProperty = serializedObject.FindProperty("_texts");
-            _modifiersProperty = serializedObject.FindProperty("_modifiers");
+            CheckForChanges(target as TweenManager, out _, out _);
         }
 
         public override void OnInspectorGUI() {
-            var createArrays = false;
-            var applyChanges = SliderChanged(_progressProperty, "Progress");
+            base.OnInspectorGUI();
+            TweenManager tweenManager = target as TweenManager;
+            CheckForChanges(tweenManager, out bool createArrays, out bool applyChanges);
 
-            if (SliderChanged(_offsetProperty, "Offset")) {
+            if (createArrays) {
+                tweenManager.Dispose(); 
+                tweenManager.CreateNativeArrays();
+            }
+            if (applyChanges) tweenManager.ForceUpdate();
+        }
+
+        private void CheckForChanges(TweenManager manager, out bool createArrays, out bool applyChanges) {
+            createArrays = false;
+            applyChanges = false;
+            
+            if (manager.Offset != _offset) {
                 createArrays = true;
                 applyChanges = true;
+                _offset = manager.Offset;
             }
-
-            if (PropertyChanged(_textsProperty)) {
+            else if (manager.Progress != _progress) {
+                applyChanges = true;
+                _progress = manager.Progress;
+            } 
+            
+            IReadOnlyList<TMP_Text> texts = TextField.Value.GetValue(manager) as IReadOnlyList<TMP_Text> ?? 
+                                          Array.Empty<TMP_Text>();
+            if (!_texts.SequenceEqual(texts)) {
                 createArrays = true;
                 applyChanges = true;
-            }
-
-            if (PropertyChanged(_modifiersProperty)) {
-                applyChanges = true;
+                _texts.Clear();
+                _texts.AddRange(texts);
             }
             
-            if (createArrays) _tweenManager.Dispose();
-            if (applyChanges) serializedObject.ApplyModifiedProperties();
-            if (createArrays) _tweenManager.CreateNativeArrays();
-            if (applyChanges) _tweenManager.ForceUpdate();
-        }
-
-        private bool SliderChanged(SerializedProperty property, string text) {
-            EditorGUI.BeginChangeCheck();
-            EditorGUILayout.Slider(property, 0, 1, text);
-            return EditorGUI.EndChangeCheck();
-        }
-
-        private bool PropertyChanged(SerializedProperty property) {
-            EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(property);
-            return EditorGUI.EndChangeCheck();
+            IReadOnlyList<CharModifier> modifiers = ModifiersField.Value.GetValue(manager) as IReadOnlyList<CharModifier> ?? 
+                                                    Array.Empty<CharModifier>();
+            if (!_modifiers.SequenceEqual(modifiers)) {
+                applyChanges = true;
+                _modifiers.Clear();
+                _modifiers.AddRange(modifiers);
+            }
         }
     }
 }

--- a/Editor/TextTweenEditor.cs
+++ b/Editor/TextTweenEditor.cs
@@ -45,7 +45,7 @@ namespace TextTween.Editor {
                 applyChanges = true;
                 _offset = manager.Offset;
             }
-            else if (manager.Progress != _progress) {
+            if (manager.Progress != _progress) {
                 applyChanges = true;
                 _progress = manager.Progress;
             } 

--- a/Editor/TextTweenEditor.cs
+++ b/Editor/TextTweenEditor.cs
@@ -1,4 +1,5 @@
 namespace TextTween.Editor {
+#if UNITY_EDITOR
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -67,4 +68,5 @@ namespace TextTween.Editor {
             }
         }
     }
+#endif
 }

--- a/Editor/TextTweenEditor.cs
+++ b/Editor/TextTweenEditor.cs
@@ -21,24 +21,25 @@ namespace TextTween.Editor {
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
 
         private void OnEnable() {
-            CheckForChanges(target as TweenManager, out _, out _);
+            CheckForChanges(target as TweenManager, out _, out _, out _);
         }
 
         public override void OnInspectorGUI() {
             base.OnInspectorGUI();
             TweenManager tweenManager = target as TweenManager;
-            CheckForChanges(tweenManager, out bool createArrays, out bool applyChanges);
+            CheckForChanges(tweenManager, out bool createArrays, out bool applyChanges,  out IReadOnlyList<TMP_Text> oldTexts);
 
             if (createArrays) {
-                tweenManager.Dispose(); 
+                tweenManager.Dispose(oldTexts); 
                 tweenManager.CreateNativeArrays();
             }
             if (applyChanges) tweenManager.ForceUpdate();
         }
 
-        private void CheckForChanges(TweenManager manager, out bool createArrays, out bool applyChanges) {
+        private void CheckForChanges(TweenManager manager, out bool createArrays, out bool applyChanges, out IReadOnlyList<TMP_Text> oldTexts) {
             createArrays = false;
             applyChanges = false;
+            oldTexts = _texts;
             
             if (manager.Offset != _offset) {
                 createArrays = true;
@@ -55,6 +56,7 @@ namespace TextTween.Editor {
             if (!_texts.SequenceEqual(texts)) {
                 createArrays = true;
                 applyChanges = true;
+                oldTexts = _texts.ToArray();
                 _texts.Clear();
                 _texts.AddRange(texts);
             }

--- a/Runtime/TweenManager.cs
+++ b/Runtime/TweenManager.cs
@@ -30,7 +30,7 @@ namespace TextTween {
                 _texts[i].ForceMeshUpdate(true);
             }
             
-            DisposeArrays();
+            DisposeArrays(_texts);
             CreateNativeArrays();
             ApplyModifiers(Progress);
             TMPro_EventManager.TEXT_CHANGED_EVENT.Add(OnTextChanged);
@@ -61,7 +61,7 @@ namespace TextTween {
 
             if (!found) return;
             
-            DisposeArrays();
+            DisposeArrays(_texts);
             CreateNativeArrays();
             ApplyModifiers(Progress);
         }
@@ -142,17 +142,17 @@ namespace TextTween {
             
             _jobHandle.Complete();
             
-            UpdateMeshes(vertices, colors);
+            UpdateMeshes(_texts, vertices, colors);
 
             _current = Progress;
             vertices.Dispose();
             colors.Dispose();
         }
 
-        private void UpdateMeshes(NativeArray<float3> vertices, NativeArray<float4> colors) {
+        private void UpdateMeshes(IReadOnlyList<TMP_Text> texts, NativeArray<float3> vertices, NativeArray<float4> colors) {
             var offset = 0;
-            for (var i = 0; i < _texts.Length; i++) {
-                var text = _texts[i];
+            for (var i = 0; i < texts.Count; i++) {
+                var text = texts[i];
                 if (text.mesh == null) continue;
                 var count = text.mesh.vertexCount;
                 text.mesh.SetVertices(vertices, offset, count);
@@ -170,16 +170,21 @@ namespace TextTween {
         }
 
         public void Dispose() {
-            DisposeArrays();
+            Dispose(_texts);
+        }
+        
+        
+        public void Dispose(IReadOnlyList<TMP_Text> texts) {
+            DisposeArrays(texts);
         }
 
-        private void DisposeArrays() {
+        private void DisposeArrays(IReadOnlyList<TMP_Text> texts) {
             _jobHandle.Complete();
             if (_charData.IsCreated) {
                 _charData.Dispose();
             }
             if (_vertices.IsCreated && _colors.IsCreated) {
-                UpdateMeshes(_vertices, _colors);
+                UpdateMeshes(texts, _vertices, _colors);
                 _vertices.Dispose();
                 _colors.Dispose();
             }


### PR DESCRIPTION
# Overview
With the current Editor script, I am unable to drag + drop modifiers or text into the Texts/Modifiers lists. The only way I am able to add items is by clicking "+" and then dragging / selecting items from there. The main way I populate these items is by dragging + dropping in editor, this breaks my workflow.

# The Fix
Instead of doing fancy serialized property checks / wizardy / custom application, I've changed the Editor code to just draw and do the normal serialization things. All of the "is this different?" code has been moved to explicit state management, which solves this particular bug. 

# Steps to Reproduce
1. Create a Tween Manager
2. Create a TMP Text instance somewhere
3. Create a Modifier somewhere
4. Try dragging either the Text or Modifier into the Texts/Modifiers fields

Expected results: Dragged Text/Modifiers are added

Actual results: Nothing happens

# Extra Info
OS: Windows 11
Unity: 2022.3.51f1