### PR TITLE
Add using statements to ensure no memory leaks

### DIFF
--- a/Runtime/TweenManager.cs
+++ b/Runtime/TweenManager.cs
@@ -132,8 +132,8 @@ namespace TextTween {
                 throw new Exception("Must have valid texts to apply modifiers.");
             }
             
-            var vertices = new NativeArray<float3>(_vertices, Allocator.TempJob);
-            var colors = new NativeArray<float4>(_colors, Allocator.TempJob);
+            using var vertices = new NativeArray<float3>(_vertices, Allocator.TempJob);
+            using var colors = new NativeArray<float4>(_colors, Allocator.TempJob);
             
             for (var i = 0; i < _modifiers.Count; i++) {
                 if (_modifiers[i] == null || !_modifiers[i].enabled) continue;
@@ -145,8 +145,6 @@ namespace TextTween {
             UpdateMeshes(vertices, colors);
 
             _current = Progress;
-            vertices.Dispose();
-            colors.Dispose();
         }
 
         private void UpdateMeshes(NativeArray<float3> vertices, NativeArray<float4> colors) {


### PR DESCRIPTION
# Overview
Currently, if there is an exception in `UpdateMeshes`, which is possible as there's a lot of direct indexing and math going on, the `vertices` and `colors` temporary native arrays will not be disposed, leading to potentially (multiple) memory leaks.

# The fix (fixes #18)
For all types that implement `IDisposable`, C# lets you create `using` statements upon declaration.  When doing so, IL is generated in such a way that the `Dispose` method on each variable is called deterministically on scope exit, regardless of exceptional circumstances or whatever. This allows for very clean and framework-supported solution to this problem.

# Tips and tricks
In general, whenever you have a variable that implements IDisposable that you both create and call Dispose on in the same scope, prefer `using` instead to ensure your variable is always disposed.