### PR TITLE
Fix Memory Leak Possibility in TweenManager.Dispose

### DIFF
--- a/Runtime/TweenManager.cs
+++ b/Runtime/TweenManager.cs
@@ -225,7 +225,8 @@ namespace TextTween
                 {
                     continue;
                 }
-                _jobHandle = _modifiers[i].Schedule(progress, vertices, colors, _charData, _jobHandle);
+                _jobHandle = _modifiers[i]
+                    .Schedule(progress, vertices, colors, _charData, _jobHandle);
             }
 
             _jobHandle.Complete();
@@ -249,7 +250,7 @@ namespace TextTween
                 {
                     continue;
                 }
-                
+
                 int count = text.mesh.vertexCount;
                 text.mesh.SetVertices(vertices, offset, count);
                 text.mesh.SetColors(colors, offset, count);
@@ -289,10 +290,12 @@ namespace TextTween
             {
                 UpdateMeshes(texts, _vertices, _colors);
             }
-            if (_vertices.IsCreated) {
+            if (_vertices.IsCreated)
+            {
                 _vertices.Dispose();
             }
-            if (_colors.IsCreated) {
+            if (_colors.IsCreated)
+            {
                 _colors.Dispose();
             }
         }

--- a/Runtime/TweenManager.cs
+++ b/Runtime/TweenManager.cs
@@ -288,7 +288,11 @@ namespace TextTween
             if (_vertices.IsCreated && _colors.IsCreated)
             {
                 UpdateMeshes(texts, _vertices, _colors);
+            }
+            if (_vertices.IsCreated) {
                 _vertices.Dispose();
+            }
+            if (_colors.IsCreated) {
                 _colors.Dispose();
             }
         }


### PR DESCRIPTION
# Overview
If, for some reason, only colors or vertices is created but not the other, current impl would fail to dispose of them, leading to a memory leak.

# The Fix
Ensure that each array is checked and disposed individually.