### PR TITLE
Fix text addition / removal bug (#28)

### DIFF
--- a/Editor/TweenManagerEditor.cs
+++ b/Editor/TweenManagerEditor.cs
@@ -36,7 +36,7 @@ namespace TextTween.Editor
         private void OnEnable()
         {
             CheckForChanges(target as TweenManager, out _, out _, out _);
-            
+
             EditorApplication.contextualPropertyMenu += OnPropertyContextMenu;
         }
 
@@ -44,12 +44,17 @@ namespace TextTween.Editor
         {
             EditorApplication.contextualPropertyMenu -= OnPropertyContextMenu;
         }
-        
+
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
             TweenManager tweenManager = (TweenManager)target;
-            CheckForChanges(tweenManager, out bool createArrays, out bool applyChanges, out IReadOnlyList<TMP_Text> oldTexts);
+            CheckForChanges(
+                tweenManager,
+                out bool createArrays,
+                out bool applyChanges,
+                out IReadOnlyList<TMP_Text> oldTexts
+            );
 
             if (createArrays)
             {
@@ -83,6 +88,7 @@ namespace TextTween.Editor
 
             if (manager.Progress != _progress)
             {
+                createArrays = true;
                 applyChanges = true;
                 _progress = manager.Progress;
             }
@@ -109,7 +115,7 @@ namespace TextTween.Editor
                 _modifiers.AddRange(modifiers);
             }
         }
-        
+
         private void OnPropertyContextMenu(GenericMenu menu, SerializedProperty property)
         {
             if (property.serializedObject.targetObject.GetType() != typeof(TweenManager))
@@ -119,29 +125,34 @@ namespace TextTween.Editor
 
             if (property.name == "_texts")
             {
-                menu.AddItem(new GUIContent("Find All Texts"), false, () => FindMissingComponents<TMP_Text>(property));
+                menu.AddItem(
+                    new GUIContent("Find All Texts"),
+                    false,
+                    () => FindMissingComponents<TMP_Text>(property)
+                );
             }
 
             if (property.name == "_modifiers")
             {
-                menu.AddItem(new GUIContent("Find All Modifiers"), false, () => FindMissingComponents<CharModifier>(property));
+                menu.AddItem(
+                    new GUIContent("Find All Modifiers"),
+                    false,
+                    () => FindMissingComponents<CharModifier>(property)
+                );
             }
         }
-        
-        private void FindMissingComponents<T>(
-            SerializedProperty serializedProperty
-        )
+
+        private void FindMissingComponents<T>(SerializedProperty serializedProperty)
             where T : UnityEngine.Object
         {
             TweenManager tweenManager = (TweenManager)target;
             T[] current = new T[serializedProperty.arraySize];
-            
+
             for (int i = 0; i < serializedProperty.arraySize; i++)
             {
                 current[i] = serializedProperty.GetArrayElementAtIndex(i).objectReferenceValue as T;
             }
 
-            
             for (int i = current.Length - 1; i >= 0; i--)
             {
                 if (current[i] != null)
@@ -158,10 +169,11 @@ namespace TextTween.Editor
                 {
                     int index = serializedProperty.arraySize;
                     serializedProperty.InsertArrayElementAtIndex(index);
-                    serializedProperty.GetArrayElementAtIndex(index).objectReferenceValue = component;
+                    serializedProperty.GetArrayElementAtIndex(index).objectReferenceValue =
+                        component;
                 }
             }
-            
+
             serializedObject.ApplyModifiedProperties();
         }
     }

--- a/Runtime/TweenManager.cs
+++ b/Runtime/TweenManager.cs
@@ -295,7 +295,6 @@ namespace TextTween
 
                 text.mesh.SetVertices(vertices, offset, count);
                 text.mesh.SetColors(colors, offset, count);
-
                 offset += count;
 
                 TMP_MeshInfo[] meshInfos = text.textInfo.meshInfo;

--- a/Runtime/TweenManager.cs
+++ b/Runtime/TweenManager.cs
@@ -48,13 +48,18 @@ namespace TextTween
             {
                 return;
             }
-            for (int i = 0; i < _texts.Length; i++)
+            if (!Application.isPlaying)
             {
-                if (_texts[i] == null)
+                for (int i = 0; i < _texts.Length; i++)
                 {
-                    continue;
+                    TMP_Text text = _texts[i];
+                    if (text == null)
+                    {
+                        continue;
+                    }
+
+                    text.ForceMeshUpdate(true);
                 }
-                _texts[i].ForceMeshUpdate(true);
             }
 
             DisposeArrays(_texts);
@@ -238,7 +243,7 @@ namespace TextTween
         {
             if (!_vertices.IsCreated || !_colors.IsCreated)
             {
-                throw new Exception("Must have valid texts to apply modifiers.");
+                return;
             }
 
             using NativeArray<float3> vertices = new(_vertices, Allocator.TempJob);
@@ -312,12 +317,11 @@ namespace TextTween
                 _charData.Dispose();
             }
             if (_vertices.IsCreated && _colors.IsCreated)
-            { 
+            {
                 if (updateMeshes)
                 {
                     UpdateMeshes(texts, _vertices, _colors);
                 }
-
             }
             if (_vertices.IsCreated)
             {


### PR DESCRIPTION
# Overview
See #28 for the issue

# The Fix (Fixes #28, Fixes #5)
I've done five things here:
1. Cached a reference to `OnTextChanged` such that we're not re-creating new delegates on every OnEnable/OnDisable call
2. Keep stateful knowledge of whether this delegate is attached
3. Update `OnTextChanged` to not call `UpdateMeshes`. This allows for safe addition, removal, and automatic re-calculation of the meshes
4. Changed ApplyModifiers to not throw. This is important - TweenManager may be initialized early than the text meshes. The hook into the TEXT_CHANGED_EVENT will be triggered when the text meshes are safely initialized.
5. Changed ForceMeshUpdate to only happen in non-PlayMode. I was having issues related to this in Play mode - I think if it's in Play Mode, things will initialize naturally.

Now, I edit text while the editor isn't playing and have it behave expectedly, AND I can do the same in play mode.