### PR TITLE
Contribution documentation + optional pre-commit hook

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "CSharpier": {
+      "version": "0.30.6",
+      "commands": ["dotnet-csharpier"]
+    }
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: local
+    hooks:
+      - id: dotnet-tool-restore
+        name: Install .NET tools
+        entry: dotnet tool restore
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages:
+          - pre-commit
+          - pre-push
+          - post-checkout
+          - post-rewrite
+        description: Install the .NET tools listed at .config/dotnet-tools.json.
+      - id: csharpier
+        name: Run CSharpier on C# files
+        entry: dotnet tool run dotnet-csharpier
+        language: system
+        types:
+          - c#
+        description: CSharpier is an opinionated C# formatter inspired by Prettier.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ Warps the lines of text according to intensity and curve provided over progress.
 | Ax1,000 | 4,327 | 2,985 | 3,391 |
 | Ax10,000 | 395 | 290 | 344 |
 | Ax1,000,000 | 14 | 14 | 15 |
+
+## Contributing
+
+This project uses [CSharpier](https://csharpier.com/) with the default configuration to enable an enforced, consistent style. If you would like to contribute, recommendation is to ensure that changed files are ran through CSharpier prior to merge. This can be done automatically through editor plugins, or, minimally, by installing a [pre-commit hook](https://pre-commit.com/#3-install-the-git-hook-scripts)


### PR DESCRIPTION
# Overview
I've added an (optional) pre-commit hook that can be installed via:
```shell
pip install pre-commit
pre-commit install
```
Assuming you have some version of python/pip installed and available on your path.

This adds a pre-commit hook that will automatically install CSharpier if it isn't installed and run it on changed files. It will reject the commit if there are any formatting diffs, and update the current staged files to be the correctly formatted files

Here's an example of me running it after adding a trailing space in `CharData`:
```powershell
D:\Code\DxMessaging-Unity\Packages\TextTween [dev/wallstop/pre-commit-csharpier*]
λ» git status
On branch dev/wallstop/pre-commit-csharpier
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .config/dotnet-tools.json
        modified:   Runtime/CharData.cs

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Runtime/CharData.cs


D:\Code\DxMessaging-Unity\Packages\TextTween [dev/wallstop/pre-commit-csharpier*]
λ» git add --all

D:\Code\DxMessaging-Unity\Packages\TextTween [dev/wallstop/pre-commit-csharpier*]
λ» git commit -m "Pre-commit test"
Install .NET tools.......................................................Passed
Run CSharpier on C# files................................................Failed
- hook id: csharpier
- files were modified by this hook

Formatted 1 files in 153ms.

D:\Code\DxMessaging-Unity\Packages\TextTween [dev/wallstop/pre-commit-csharpier*]
λ» git status
On branch dev/wallstop/pre-commit-csharpier
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .config/dotnet-tools.json
        modified:   Runtime/CharData.cs

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Runtime/CharData.cs
```

Maybe what isn't clear here is that, after I tried to run `git commit`, it ran CSharpier and properly formatted the file, then left it in my staging area for me to decide if it's a change I want.

If you enable this, you no longer have to worry about whether or not you have CSharpier installed or if you're actively running it or whatever, it'll run automatically when you go to check in!

Added some brief documentation about CSharpier usage as well as a link to the installation documentation for `pre-commit`.
