### PR TITLE
Fix npm-publish for manual runs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,9 +27,18 @@ jobs:
       - name: Check if version changed
         id: version_check
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Manual trigger detected. Skipping version check."
+            NEW_VERSION=$(jq -r '.version' package.json)
+            echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
             echo "should_publish=true" >> $GITHUB_ENV
+            if [[ "$NEW_VERSION" == *"rc"* ]]; then
+              echo "This is a pre-release (next tag)."
+              echo "NPM_TAG=next" >> $GITHUB_ENV
+            else
+              echo "This is a stable release (latest tag)."
+              echo "NPM_TAG=latest" >> $GITHUB_ENV
+            fi
           else
             PREV_VERSION=$(git show HEAD~1:package.json | jq -r '.version' || echo "0.0.0")
             NEW_VERSION=$(jq -r '.version' package.json)

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check if version changed
         id: version_check
         run: |
-         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Manual trigger detected. Skipping version check."
             NEW_VERSION=$(jq -r '.version' package.json)
             echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
# Overview

It looks like you lifted the npm publish script I had in some of my repos (which is cool!). The script is new and mostly AI-generated, I don't know yml / whatever config language github uses to run code in its actions and I don't want to learn.

Anyway, the current script has a bug where if you run it manually, it doesn't inject the appropriate NPM variables (specifically version) into the environment, which will cause manual runs to fail 100% of the time, even if the latest bits have a new version.

I've tested this and this new version works for manual triggers. It can probably be cleaner but not really worth the time to clean up IMO.

# PR Feedback

Happy to tweak / clean things up if you'd like it to be cleaner.