### PR TITLE
Initialize List values in TextTweenManager

### DIFF
--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -23,10 +23,10 @@ namespace TextTween
         internal int BufferSize;
 
         [SerializeField]
-        internal List<TMP_Text> Texts;
+        internal List<TMP_Text> Texts = new();
 
         [SerializeField]
-        internal List<CharModifier> Modifiers;
+        internal List<CharModifier> Modifiers = new();
 
         [SerializeField]
         internal List<MeshData> MeshData = new();


### PR DESCRIPTION
# Overview
In some upcoming editor changes I'd like to make, the editor code assumes that the list values in `Text` and `Modifiers` will be non-null. Generally Unity is good about initializing these, but for some reason the editor code was running before Unity's initialization. So to be on the safe side, let's default-initialize these to empty lists.

# The Fix
Initialize `Texts` and `Modifiers` to empty lists.