### PR TITLE
Dynamic smart buffer size

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -67,7 +67,7 @@ namespace TextTween.Editor
                 _previous = current;
                 TextTweenManager tweenManager = ((TextTweenManager)target);
                 tweenManager.Apply();
-                tweenManager.TryUpdateBufferSize();
+                tweenManager.TryUpdateComputedBufferSize();
             }
         }
     }

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -30,6 +30,7 @@ namespace TextTween.Editor
 
         public override void OnInspectorGUI()
         {
+            TextTweenManager tweenManager = ((TextTweenManager)target);
             EditorGUI.BeginChangeCheck();
             base.OnInspectorGUI();
             if (EditorGUI.EndChangeCheck())
@@ -65,10 +66,17 @@ namespace TextTween.Editor
                     _manager.Add(o);
                 }
                 _previous = current;
-                TextTweenManager tweenManager = ((TextTweenManager)target);
                 tweenManager.Apply();
-                tweenManager.TryUpdateComputedBufferSize();
             }
+            /*
+                Change check is failing us in two cases:
+                    1. Users drag a text element into `Texts`. This is not caught and the buffer size is not updated.
+                    2. Users remove a text element from `Texts. From my testing, TweenManager still knows about the
+                        state *previous* to the removal, so the calculated buffer size is incorrect.
+                Buffer size calculation is important, cheap, and change-aware, it's ok to run this OnInspectorGUI to
+                ensure proper buffer size.
+             */
+            tweenManager.TryUpdateComputedBufferSize();
         }
     }
 }

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -65,7 +65,9 @@ namespace TextTween.Editor
                     _manager.Add(o);
                 }
                 _previous = current;
-                ((TextTweenManager)target).Apply();
+                TextTweenManager tweenManager = ((TextTweenManager)target);
+                tweenManager.Apply();
+                tweenManager.TryUpdateBufferSize();
             }
         }
     }

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -34,8 +34,8 @@ namespace TextTween
 
         [Header("Advanced")]
         [Tooltip(
-            "The sum total number of vertices used for buffers across all Text instances being managed.\n"
-                + "Runtime buffer size will be the max of this value and ComputedBufferSize.\n"
+            "The sum total number of vertices used for buffers across all Text instances being managed.\n\n"
+                + "Runtime buffer size will be the max of this value and ComputedBufferSize.\n\n"
                 + "<color=yellow>Should only be set if you know your text is going to grow to some size in the future"
                 + "</color>"
         )]

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -12,6 +12,9 @@ namespace TextTween
     using Unity.Jobs;
     using UnityEngine;
     using Utilities;
+#if UNITY_EDITOR
+    using UnityEditor;
+#endif
 
     [Serializable, ExecuteInEditMode]
     public class TextTweenManager : MonoBehaviour, IDisposable
@@ -177,6 +180,9 @@ namespace TextTween
             if (Application.isEditor && !Application.isPlaying)
             {
                 BufferSize = capacity ?? CalculateCapacity(toIgnore);
+#if UNITY_EDITOR
+                EditorUtility.SetDirty(this);
+#endif
             }
         }
 

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -112,7 +112,7 @@ namespace TextTween
 
             Move(meshData.Trail, meshData.Offset, length).Complete();
 
-            TryUpdateBufferSize(toIgnore: text);
+            TryUpdateBufferSize();
         }
 
         internal void Change(UnityEngine.Object obj)
@@ -160,12 +160,12 @@ namespace TextTween
             TryUpdateBufferSize(capacity);
         }
 
-        private int CalculateCapacity(TMP_Text toIgnore = null)
+        private int CalculateCapacity()
         {
             int vertexCount = 0;
             foreach (TMP_Text text in Texts)
             {
-                if (text != null && toIgnore != text)
+                if (text != null)
                 {
                     vertexCount += text.GetVertexCount();
                 }
@@ -174,12 +174,12 @@ namespace TextTween
             return vertexCount;
         }
 
-        private void TryUpdateBufferSize(int? capacity = null, TMP_Text toIgnore = null)
+        internal void TryUpdateBufferSize(int? capacity = null)
         {
             // Update LKG of buffer size if we're in a place where serialization is ok
             if (Application.isEditor && !Application.isPlaying)
             {
-                BufferSize = capacity ?? CalculateCapacity(toIgnore);
+                BufferSize = capacity ?? CalculateCapacity();
 #if UNITY_EDITOR
                 EditorUtility.SetDirty(this);
 #endif

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -108,6 +108,8 @@ namespace TextTween
             }
 
             Move(meshData.Trail, meshData.Offset, length).Complete();
+
+            TryUpdateBufferSize(toIgnore: text);
         }
 
         internal void Change(UnityEngine.Object obj)
@@ -149,14 +151,33 @@ namespace TextTween
 
         public void Allocate()
         {
+            int capacity = CalculateCapacity();
+            Original.EnsureCapacity(capacity);
+            Modified.EnsureCapacity(capacity);
+            TryUpdateBufferSize(capacity);
+        }
+
+        private int CalculateCapacity(TMP_Text toIgnore = null)
+        {
             int vertexCount = 0;
             foreach (TMP_Text text in Texts)
             {
-                vertexCount += text.GetVertexCount();
+                if (text != null && toIgnore != text)
+                {
+                    vertexCount += text.GetVertexCount();
+                }
             }
 
-            Original.EnsureCapacity(vertexCount);
-            Modified.EnsureCapacity(vertexCount);
+            return vertexCount;
+        }
+
+        private void TryUpdateBufferSize(int? capacity = null, TMP_Text toIgnore = null)
+        {
+            // Update LKG of buffer size if we're in a place where serialization is ok
+            if (Application.isEditor && !Application.isPlaying)
+            {
+                BufferSize = capacity ?? CalculateCapacity(toIgnore);
+            }
         }
 
         private JobHandle Move(int from, int to, int length, JobHandle dependsOn = default)

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -196,8 +196,13 @@ namespace TextTween
             // Update LKG of buffer size if we're in a place where serialization is ok (game not playing)
             if (!Application.isPlaying)
             {
-                ComputedBufferSize = capacity ?? CalculateCapacity();
-                EditorUtility.SetDirty(this);
+                int oldBufferSize = ComputedBufferSize;
+                int newBufferSize = capacity ?? CalculateCapacity();
+                if (oldBufferSize != newBufferSize)
+                {
+                    ComputedBufferSize = newBufferSize;
+                    EditorUtility.SetDirty(this);
+                }
             }
 #endif
         }


### PR DESCRIPTION
# Overview
Right now the buffer size calculation is manual. If you set it to a good value, great! However, if the value isn't smart, each time the TextTweenManager does anything (RE: is enabled), at least two allocations are done - one for the initial buffer size, then another when the actual size needed is calculated (and is more than the buffer size). Since the default value is 0 and nothing currently changes this except the user, it is highly likely that two allocations are needed.

To address this, I've added code to the mutation operations that will lazily/properly calculate the necessary buffer size and, if the editor is in the right state (editor and not running), update the buffer size to the best size + dirty the asset. I've run into problems with updating serialized property at runtime / non-editor contexts, which is why this check exists.

With smart buffer sizes, this reduces the total allocations done on initialization from 2 to 1. The only thing that will cause additional buffer allocations is text content changes at runtime, which may or may not increase the vertex count / total buffer capacity needed.