### PR TITLE
Hide TextTweenManager internal stuff by default

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -36,6 +36,7 @@ namespace TextTween.Editor
                 nameof(TextTweenManager.BufferSize),
                 nameof(TextTweenManager.MeshData)
             );
+            serializedObject.ApplyModifiedProperties();
             if (EditorGUI.EndChangeCheck())
             {
                 List<TMP_Text> current = new(_textsProperty.arraySize);

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -31,7 +31,11 @@ namespace TextTween.Editor
         public override void OnInspectorGUI()
         {
             EditorGUI.BeginChangeCheck();
-            base.OnInspectorGUI();
+            DrawPropertiesExcluding(
+                serializedObject,
+                nameof(TextTweenManager.BufferSize),
+                nameof(TextTweenManager.MeshData)
+            );
             if (EditorGUI.EndChangeCheck())
             {
                 List<TMP_Text> current = new(_textsProperty.arraySize);


### PR DESCRIPTION
# Overview
Right now, buffersize and MeshData are exposed in the inspector. These are internal bits of state that should not be modified by the standard user, these should be auto-managed by our custom inspector / state. However, it is still useful to be able to expose them if you *really* need to.

Enter `DrawPropertiesExcluding`. This will draw all properties *except* some particular ones. But, if you change the inspector view to `Debug`, they come back! So power users still have control, if control is really necessary.

Normal Inspector:
![image](https://github.com/user-attachments/assets/d194f135-f2d1-458c-9a20-cb7d62453bde)

Debug Inspector:
![image](https://github.com/user-attachments/assets/970ceb93-095f-432a-8c05-c9cab5a33a63)

We now need `serializedObject.ApplyModifiedProperties()` as nothing is doing this for us with this new draw call. If we don't, the change check will always return false and the user will not be able to update the TextTweenManager.
