### PR TITLE
Minor perf gains in extensions

### DIFF
--- a/Runtime/Utilities/TextDataUtility.cs
+++ b/Runtime/Utilities/TextDataUtility.cs
@@ -29,24 +29,26 @@ namespace TextTween.Utilities
         }
 
         public static bool TryGetValue(
-            this IEnumerable<MeshData> collection,
+            this IReadOnlyList<MeshData> collection,
             TMP_Text text,
             out MeshData meshData
         )
         {
-            meshData = default;
-            foreach (MeshData data in collection)
+            for (int i = 0; i < collection.Count; i++)
             {
+                MeshData data = collection[i];
                 if (data.Text == text)
                 {
                     meshData = data;
                     return true;
                 }
             }
+
+            meshData = default;
             return false;
         }
 
-        public static int GetIndex(this IList<MeshData> collection, TMP_Text text)
+        public static int GetIndex(this IReadOnlyList<MeshData> collection, TMP_Text text)
         {
             for (int i = 0; i < collection.Count; i++)
             {


### PR DESCRIPTION
# Overview
Current extensions were using IEnumerables / IList with allocates an enumerator (boxed) when doing the for loop, creating unnecessary garbage.

Changed each of these (`Contains`, `TryGetValue`) to use a counting for loop which does not allocate, but produces the same result. Method signatures needed to be updated to use `IReadOnlyList` in place of `IList` (do not need the mutable version) and `IEnumerable` (all callers are lists/arrays)