### PR TITLE
Force Mesh Updates

### DIFF
--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -61,6 +61,22 @@ namespace TextTween
 
         internal void OnEnable()
         {
+            /*
+                It's very likely that we'll be parent components of the TMP texts that we're managing. In some cases, that
+                means we'll be enabled before they are, and their state will be dirty. I've run into several cases in
+                the editor where, without having the text's mesh updated, our internals will try to interact with TMP
+                and TMP internals will be non-initialized and throw null reference exceptions.
+                
+                To avoid this, force-update the meshes to ensure we're in a known-good state.
+             */
+            foreach (TMP_Text text in Texts)
+            {
+                if (text != null)
+                {
+                    text.ForceMeshUpdate(ignoreActiveState: true);
+                }
+            }
+
             int bufferSize = Math.Max(ExplicitBufferSize, ComputedBufferSize);
             bufferSize = Math.Max(0, bufferSize);
             Original = new MeshArray(bufferSize, Allocator.Persistent);


### PR DESCRIPTION
# Overview
When playing around with TextTweenManager in the editor, I can fairly reliably trigger a case where TextTweenManager triggers null reference exceptions in its managed TMP texts.

My setup is:
```
Manager ( + Modifier)
   > TMP Child 1
   > TMP Child 2
```

It seems to be that on initial creation/assembly load, things are fine. If I change a bit of code unrelated to TextTweenManager and the domain reloads, I get null reference exceptions in non-TextTween code, like GUI Repaint events of the TMP instances.

I don't fully understand why, but my suspicion is that it's related to either the custom editor code or the fact that our TextTweenManager is always enabled.

Forcing mesh updates in OnEnable ensures a known good state and appears to fix the issue for me.

Sample exception:
```
NullReferenceException: Object reference not set to an instance of an object
TMPro.TMP_Text.FillCharacterVertexBuffers (System.Int32 i, System.Int32 index_X4) (at ./Library/PackageCache/com.unity.textmeshpro@3.0.7/Scripts/Runtime/TMP_Text.cs:5525)
TMPro.TextMeshPro.GenerateTextMesh () (at ./Library/PackageCache/com.unity.textmeshpro@3.0.7/Scripts/Runtime/TMPro_Private.cs:3844)
TMPro.TextMeshPro.OnPreRenderObject () (at ./Library/PackageCache/com.unity.textmeshpro@3.0.7/Scripts/Runtime/TMPro_Private.cs:1562)
TMPro.TextMeshPro.Rebuild (UnityEngine.UI.CanvasUpdate update) (at ./Library/PackageCache/com.unity.textmeshpro@3.0.7/Scripts/Runtime/TextMeshPro.cs:280)
TMPro.TMP_UpdateManager.DoRebuilds () (at ./Library/PackageCache/com.unity.textmeshpro@3.0.7/Scripts/Runtime/TMP_UpdateManager.cs:177)
UnityEngine.Canvas.SendWillRenderCanvases () (at <39d90675b17b498d9253fd13078b5f36>:0)
```
   