### PR TITLE
Editor fix to handle drag/drop

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -11,7 +11,6 @@ namespace TextTween.Editor
         private TextTweenManager _manager;
         private SerializedProperty _textsProperty;
         private SerializedProperty _modifiersProperty;
-        private ReorderableList _reorderableList;
 
         private readonly List<TMP_Text> _previousTexts = new();
         private readonly List<CharModifier> _previousModifiers = new();
@@ -75,7 +74,7 @@ namespace TextTween.Editor
         }
 
         private static IEnumerable<T> GetCurrentArrayValues<T>(SerializedProperty property)
-            where T : Object
+            where T : UnityEngine.Object
         {
             for (int i = 0; i < property.arraySize; i++)
             {
@@ -85,10 +84,12 @@ namespace TextTween.Editor
 
         /*
             For some reason, Editor ChangeCheck does not properly identify when users drag elements into a list.
-            So we have to resort to something like this
+            So we have to resort to something like this.
+            
+            Preference is to have non-garbage generating code (like this) in the OnGUI checks for maximum performance.
          */
         private static bool HasChanged<T>(List<T> previous, SerializedProperty property)
-            where T : Object
+            where T : UnityEngine.Object
         {
             if (property.arraySize != previous.Count)
             {

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -10,19 +10,18 @@ namespace TextTween.Editor
     {
         private TextTweenManager _manager;
         private SerializedProperty _textsProperty;
+        private SerializedProperty _modifiersProperty;
+        private ReorderableList _reorderableList;
 
-        private List<TMP_Text> _previous = new();
+        private readonly List<TMP_Text> _previousTexts = new();
+        private readonly List<CharModifier> _previousModifiers = new();
 
         private void OnEnable()
         {
             _manager = (TextTweenManager)target;
             _textsProperty = serializedObject.FindProperty(nameof(TextTweenManager.Texts));
-            for (int i = 0; i < _textsProperty.arraySize; i++)
-            {
-                _previous.Add(
-                    (TMP_Text)_textsProperty.GetArrayElementAtIndex(i).objectReferenceValue
-                );
-            }
+            _modifiersProperty = serializedObject.FindProperty(nameof(TextTweenManager.Modifiers));
+            HydrateCurrentState();
         }
 
         public override void OnInspectorGUI()
@@ -30,20 +29,18 @@ namespace TextTween.Editor
             TextTweenManager tweenManager = ((TextTweenManager)target);
             EditorGUI.BeginChangeCheck();
             base.OnInspectorGUI();
-            if (EditorGUI.EndChangeCheck())
+            if (
+                EditorGUI.EndChangeCheck()
+                || HasChanged(_previousTexts, _textsProperty)
+                || HasChanged(_previousModifiers, _modifiersProperty)
+            )
             {
-                List<TMP_Text> current = new(_textsProperty.arraySize);
-                for (int i = 0; i < _textsProperty.arraySize; i++)
-                {
-                    current.Add(
-                        (TMP_Text)_textsProperty.GetArrayElementAtIndex(i).objectReferenceValue
-                    );
-                }
+                List<TMP_Text> current = Hydrate<TMP_Text>(_textsProperty);
 
                 HashSet<TMP_Text> add = current.ToHashSet();
-                HashSet<TMP_Text> remove = _previous.ToHashSet();
+                HashSet<TMP_Text> remove = _previousTexts.ToHashSet();
 
-                add.ExceptWith(_previous);
+                add.ExceptWith(_previousTexts);
                 remove.ExceptWith(current);
 
                 foreach (TMP_Text o in remove)
@@ -62,18 +59,54 @@ namespace TextTween.Editor
                     }
                     _manager.Add(o);
                 }
-                _previous = current;
                 tweenManager.Apply();
+                // Force buffer re-computation, when Remove() is called, Texts appears to be using previous Texts state.
+                tweenManager.TryUpdateComputedBufferSize();
+                HydrateCurrentState();
             }
-            /*
-                Change check is failing us in two cases:
-                    1. Users drag a text element into `Texts`. This is not caught and the buffer size is not updated.
-                    2. Users remove a text element from `Texts. From my testing, TweenManager still knows about the
-                        state *previous* to the removal, so the calculated buffer size is incorrect.
-                Buffer size calculation is important, cheap, and change-aware, it's ok to run this OnInspectorGUI to
-                ensure proper buffer size.
-             */
-            tweenManager.TryUpdateComputedBufferSize();
+        }
+
+        private void HydrateCurrentState()
+        {
+            _previousTexts.Clear();
+            _previousTexts.AddRange(Hydrate<TMP_Text>(_textsProperty));
+            _previousModifiers.Clear();
+            _previousModifiers.AddRange(Hydrate<CharModifier>(_modifiersProperty));
+        }
+
+        private static List<T> Hydrate<T>(SerializedProperty property)
+            where T : Object
+        {
+            List<T> current = new(property.arraySize);
+            for (int i = 0; i < property.arraySize; i++)
+            {
+                current.Add(property.GetArrayElementAtIndex(i).objectReferenceValue as T);
+            }
+
+            return current;
+        }
+
+        /*
+            For some reason, Editor ChangeCheck does not properly identify when users drag elements into a list.
+            So we have to resort to something like this
+         */
+        private static bool HasChanged<T>(List<T> previous, SerializedProperty property)
+            where T : Object
+        {
+            if (property.arraySize != previous.Count)
+            {
+                return true;
+            }
+
+            for (int i = 0; i < property.arraySize; i++)
+            {
+                if (previous[i] != property.GetArrayElementAtIndex(i).objectReferenceValue)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -35,7 +35,7 @@ namespace TextTween.Editor
                 || HasChanged(_previousModifiers, _modifiersProperty)
             )
             {
-                List<TMP_Text> current = Hydrate<TMP_Text>(_textsProperty);
+                List<TMP_Text> current = GetCurrentArrayValues<TMP_Text>(_textsProperty).ToList();
 
                 HashSet<TMP_Text> add = current.ToHashSet();
                 HashSet<TMP_Text> remove = _previousTexts.ToHashSet();
@@ -69,21 +69,18 @@ namespace TextTween.Editor
         private void HydrateCurrentState()
         {
             _previousTexts.Clear();
-            _previousTexts.AddRange(Hydrate<TMP_Text>(_textsProperty));
+            _previousTexts.AddRange(GetCurrentArrayValues<TMP_Text>(_textsProperty));
             _previousModifiers.Clear();
-            _previousModifiers.AddRange(Hydrate<CharModifier>(_modifiersProperty));
+            _previousModifiers.AddRange(GetCurrentArrayValues<CharModifier>(_modifiersProperty));
         }
 
-        private static List<T> Hydrate<T>(SerializedProperty property)
+        private static IEnumerable<T> GetCurrentArrayValues<T>(SerializedProperty property)
             where T : Object
         {
-            List<T> current = new(property.arraySize);
             for (int i = 0; i < property.arraySize; i++)
             {
-                current.Add(property.GetArrayElementAtIndex(i).objectReferenceValue as T);
+                yield return property.GetArrayElementAtIndex(i).objectReferenceValue as T;
             }
-
-            return current;
         }
 
         /*


### PR DESCRIPTION
# Overview
For some reason, the editor doesn't cleanly handle drag/drop into lists (change check thinks nothing has changed). This causes really bad issues, like `MeshData` not getting created/updated as appropriately.

# The Fix
Add simple/explicit checks for each serialized array property that we're interested in, then do manual comparisons to see if they've changed and act accordingly.

https://github.com/user-attachments/assets/f43c0df9-6fb6-45a2-ad38-91fef4298e3e

