### PR TITLE
Component removal

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -4,14 +4,12 @@ namespace TextTween.Editor
     using System.Linq;
     using TMPro;
     using UnityEditor;
-    using UnityEditorInternal;
 
     [CustomEditor(typeof(TextTweenManager))]
     public class TextDataManagerInspector : Editor
     {
         private TextTweenManager _manager;
         private SerializedProperty _textsProperty;
-        private ReorderableList _reorderableList;
 
         private List<TMP_Text> _previous = new();
 

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -5,7 +5,6 @@ namespace TextTween.Editor
     using TMPro;
     using UnityEditor;
     using UnityEditorInternal;
-    using UnityEngine;
 
     [CustomEditor(typeof(TextTweenManager))]
     public class TextDataManagerInspector : Editor

--- a/Runtime/MeshArray.cs
+++ b/Runtime/MeshArray.cs
@@ -57,7 +57,7 @@ namespace TextTween
             for (int i = 0; i < modifiers.Count; i++)
             {
                 CharModifier modifier = modifiers[i];
-                if (!modifier.enabled)
+                if (modifier == null || !modifier.enabled)
                 {
                     continue;
                 }

--- a/Runtime/MeshData.cs
+++ b/Runtime/MeshData.cs
@@ -21,7 +21,7 @@ namespace TextTween
 
         public void Apply(MeshArray array)
         {
-            if (Text == null || Text.mesh == null)
+            if (Text == null || Text.mesh == null || Text.text.Length == 0)
             {
                 return;
             }

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -80,7 +80,10 @@ namespace TextTween
         {
             foreach (TMP_Text text in Texts)
             {
-                text.ForceMeshUpdate(true);
+                if (text != null)
+                {
+                    text.ForceMeshUpdate(true);
+                }
             }
         }
 

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -76,6 +76,14 @@ namespace TextTween
             Dispose();
         }
 
+        internal void OnDestroy()
+        {
+            foreach (TMP_Text text in Texts)
+            {
+                text.ForceMeshUpdate(true);
+            }
+        }
+
         private void Update()
         {
             if (!Application.isPlaying || Mathf.Approximately(_progress, Progress))


### PR DESCRIPTION
I've started with the component removal part but ended up adding few more fixes.


### Fixes #45 
Added `ForceMeshUpdate` to `OnDestroy` to revert TMP's to original state when component gets removed in editor or runtime.

### Fixes #46 
This was an odd one, the easy and intuitive solution was to skip the TMP modification when text length is 0. This allows `TMP` to do whatever it does hide the text. Planning to take a peak under the hood and see what they actually do to hide it when i have some time.

Fixes #47 
WarpModifier has been a pain sometime and the sole responsible of `AABB` errors. Main issue here is the hidden characters which TMP loves to use. When the width is 0 or really close to zero, the normalize function fails to normalize a direction which ends up in a `NaN` angle calculation then chaos reigns. I've added some guards to avoid such cases, and a final guard to prevent vertex position of ever being `NaN`.