### PR TITLE
Only handle unique char modifiers

### DIFF
--- a/Runtime/MeshArray.cs
+++ b/Runtime/MeshArray.cs
@@ -18,7 +18,8 @@ namespace TextTween
         private NativeArray<float2> _uvs2;
         private NativeArray<CharData> _chars;
 
-        private readonly HashSet<CharModifier> _uniqueModifiers = new();
+        // Keep lazy since only one MeshArray will be doing operations
+        private HashSet<CharModifier> _uniqueModifiers;
 
         public MeshArray(int length, Allocator allocator)
         {
@@ -56,6 +57,7 @@ namespace TextTween
         public JobHandle Schedule(float progress, IReadOnlyList<CharModifier> modifiers)
         {
             JobHandle handle = new();
+            _uniqueModifiers ??= new HashSet<CharModifier>();
             _uniqueModifiers.Clear();
             for (int i = 0; i < modifiers.Count; i++)
             {

--- a/Runtime/MeshArray.cs
+++ b/Runtime/MeshArray.cs
@@ -18,6 +18,8 @@ namespace TextTween
         private NativeArray<float2> _uvs2;
         private NativeArray<CharData> _chars;
 
+        private readonly HashSet<CharModifier> _uniqueModifiers = new();
+
         public MeshArray(int length, Allocator allocator)
         {
             _vertices = new NativeArray<float3>(length, allocator);
@@ -54,10 +56,11 @@ namespace TextTween
         public JobHandle Schedule(float progress, IReadOnlyList<CharModifier> modifiers)
         {
             JobHandle handle = new();
+            _uniqueModifiers.Clear();
             for (int i = 0; i < modifiers.Count; i++)
             {
                 CharModifier modifier = modifiers[i];
-                if (modifier == null || !modifier.enabled)
+                if (modifier == null || !modifier.enabled || !_uniqueModifiers.Add(modifier))
                 {
                     continue;
                 }


### PR DESCRIPTION
# Overview
&check; Fixes #49 

Not sure if this is even something you want to handle, arguably users should not be adding duplicate char modifiers. But without this, all the text data gets corrupted when duplicate modifiers are added (at least in my Editor). Personal preference is "software that is as safe as possible even when the user does stupid stuff", this is a step in that direction.