### PR TITLE
Clean editor deletion

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -44,10 +44,6 @@ namespace TextTween.Editor
 
                 foreach (TMP_Text o in remove)
                 {
-                    if (o == null)
-                    {
-                        continue;
-                    }
                     _manager.Remove(o);
                 }
                 foreach (TMP_Text o in add)
@@ -56,6 +52,8 @@ namespace TextTween.Editor
                     {
                         continue;
                     }
+                    // Make sure Text mesh is valid
+                    o.ForceMeshUpdate(ignoreActiveState: true);
                     _manager.Add(o);
                 }
                 tweenManager.Apply();

--- a/Runtime/MeshData.cs
+++ b/Runtime/MeshData.cs
@@ -2,6 +2,8 @@ namespace TextTween
 {
     using System;
     using TMPro;
+    using UnityEngine;
+    using UnityEngine.Serialization;
     using Utilities;
 
     [Serializable]
@@ -10,9 +12,28 @@ namespace TextTween
         public static readonly MeshData Empty = new(null);
 
         public TMP_Text Text;
-        public int Offset;
-        public int Length;
-        public int Trail => Length + Offset;
+
+        public int Offset
+        {
+            get => Text == null ? 0 : _offset;
+            private set => _offset = value;
+        }
+
+        public int Length
+        {
+            get => Text == null ? 0 : _length;
+            private set => _length = value;
+        }
+
+        public int Trail => Text == null ? 0 : _length + _offset;
+
+        [SerializeField]
+        [FormerlySerializedAs("Offset")]
+        internal int _offset;
+
+        [SerializeField]
+        [FormerlySerializedAs("Length")]
+        private int _length;
 
         public MeshData(TMP_Text text)
         {
@@ -32,7 +53,11 @@ namespace TextTween
         public void Update(MeshArray meshArray, int offset)
         {
             int length = Text.GetVertexCount();
-            meshArray.CopyFrom(Text, length, offset);
+            if (length != 0)
+            {
+                meshArray.CopyFrom(Text, length, offset);
+            }
+
             Offset = offset;
             Length = length;
         }

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -244,7 +244,7 @@ namespace TextTween
                     continue;
                 }
 
-                data.Offset += delta;
+                data._offset += delta;
             }
 
             return Original.Move(from, to, length, dependsOn);


### PR DESCRIPTION
# Overview
&check; Addresses #52. Tested at editor time and runtime.

If the user doesn't clean up the stale TMP instances attached to the TextTweenManager, it's ok, nothing bad happens, we just maintain some extra MeshData state that's irrelevant.


https://github.com/user-attachments/assets/00801d0b-fb6b-4511-85fe-693310b28aa6