### PR TITLE
Pretty Editor (v1)

### DIFF
--- a/Editor/ReadOnlyPropertyDrawer.cs
+++ b/Editor/ReadOnlyPropertyDrawer.cs
@@ -1,0 +1,26 @@
+﻿namespace TextTween.Editor
+{
+#if UNITY_EDITOR
+    using Attributes;
+    using UnityEditor;
+    using UnityEngine;
+
+    // https://www.patrykgalach.com/2020/01/20/readonly-attribute-in-unity-editor/
+    [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
+    public sealed class ReadOnlyPropertyDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            bool previousGUIState = GUI.enabled;
+            GUI.enabled = false;
+            _ = EditorGUI.PropertyField(position, property, label);
+            GUI.enabled = previousGUIState;
+        }
+    }
+#endif
+}

--- a/Editor/ReadOnlyPropertyDrawer.cs.meta
+++ b/Editor/ReadOnlyPropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4e4264dd9d24457495ecb350ca494003
+timeCreated: 1746025034

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -26,10 +26,11 @@ namespace TextTween.Editor
         public override void OnInspectorGUI()
         {
             TextTweenManager tweenManager = ((TextTweenManager)target);
+            serializedObject.Update();
             EditorGUI.BeginChangeCheck();
-            base.OnInspectorGUI();
+            DrawPropertiesExcluding(serializedObject, nameof(TextTweenManager.MeshData));
             if (
-                EditorGUI.EndChangeCheck()
+                serializedObject.ApplyModifiedProperties()
                 || HasChanged(_previousTexts, _textsProperty)
                 || HasChanged(_previousModifiers, _modifiersProperty)
             )

--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -27,7 +27,6 @@ namespace TextTween.Editor
         {
             TextTweenManager tweenManager = ((TextTweenManager)target);
             serializedObject.Update();
-            EditorGUI.BeginChangeCheck();
             DrawPropertiesExcluding(serializedObject, nameof(TextTweenManager.MeshData));
             if (
                 serializedObject.ApplyModifiedProperties()

--- a/Runtime/Attributes.meta
+++ b/Runtime/Attributes.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56bc22a66fc34c029b15baea744532d7
+timeCreated: 1746024995

--- a/Runtime/Attributes/ReadOnlyAttribute.cs
+++ b/Runtime/Attributes/ReadOnlyAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace TextTween.Attributes
+{
+    using PropertyAttribute = UnityEngine.PropertyAttribute;
+
+    /// <summary>
+    ///     TextTween internal, simple, read-only attribute. Does not support complex types.
+    /// </summary>
+    public sealed class ReadOnlyAttribute : PropertyAttribute { }
+}

--- a/Runtime/Attributes/ReadOnlyAttribute.cs
+++ b/Runtime/Attributes/ReadOnlyAttribute.cs
@@ -5,5 +5,5 @@
     /// <summary>
     ///     TextTween internal, simple, read-only attribute. Does not support complex types.
     /// </summary>
-    public sealed class ReadOnlyAttribute : PropertyAttribute { }
+    internal sealed class ReadOnlyAttribute : PropertyAttribute { }
 }

--- a/Runtime/Attributes/ReadOnlyAttribute.cs.meta
+++ b/Runtime/Attributes/ReadOnlyAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5c7aaa8f22094af4b8cc17cdb03f1206
+timeCreated: 1746025002

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -7,6 +7,7 @@ namespace TextTween
 {
     using System;
     using System.Collections.Generic;
+    using Attributes;
     using TMPro;
     using Unity.Collections;
     using Unity.Jobs;
@@ -20,6 +21,7 @@ namespace TextTween
     [Serializable, ExecuteInEditMode]
     public class TextTweenManager : MonoBehaviour, IDisposable
     {
+        [Header("Tween Config")]
         [Range(0, 1f)]
         public float Progress;
 
@@ -29,15 +31,12 @@ namespace TextTween
         [SerializeField]
         internal List<CharModifier> Modifiers = new();
 
-        [SerializeField]
-        internal List<MeshData> MeshData = new();
-
         [Header("Advanced")]
         [Tooltip(
-            "The sum total number of vertices used for buffers across all Text instances being managed.\n\n"
-                + "Runtime buffer size will be the max of this value and ComputedBufferSize.\n\n"
-                + "<color=yellow>Should only be set if you know your text is going to grow to some size in the future"
-                + "</color>"
+            "<color=yellow>Should only be set if you know your text is going to grow to some size in the future."
+                + "</color>\n\n"
+                + "Explicit Buffer Size is the sum total number of vertices used for buffers across all Text instances "
+                + "being managed.\n\nRuntime buffer size will be the max of this value and ComputedBufferSize."
         )]
         public int ExplicitBufferSize = -1;
 
@@ -45,8 +44,12 @@ namespace TextTween
             "Auto-configured by TextTween internals, changes to this value will be overwritten."
         )]
         [FormerlySerializedAs("BufferSize")]
+        [Attributes.ReadOnly]
         [SerializeField]
         internal int ComputedBufferSize;
+
+        [SerializeField]
+        internal List<MeshData> MeshData = new();
 
         internal MeshArray Original;
         internal MeshArray Modified;
@@ -154,14 +157,16 @@ namespace TextTween
             }
 
             Move(meshData.Trail, meshData.Offset, length).Complete();
-
             TryUpdateComputedBufferSize();
         }
 
         internal void Change(UnityEngine.Object obj)
         {
             if (Texts == null)
+            {
                 return;
+            }
+
             TMP_Text tmp = (TMP_Text)obj;
 
             int index = MeshData.GetIndex(tmp);


### PR DESCRIPTION
# Overview
Right now we expose some internal data that shouldn't be edited to the user:
- `MeshData`
- `Computed Buffer Size`

Computed Buffer Size is useful to *view* so that users can see approximately what value they need for the `Explicit Buffer Size`, but should not be *editable*.

This PR does four things.
1. Hides `MeshData` from all but the most adept user's eyes.
2. Makes `Computed Buffer Size` non-modifiable.
3. Adds a "Tween Config" header to the `Progress`/`Texts`/`Modifiers` properties.
4. Slight tweaks to the verbiage in `Explicit Buffer Size`.

Here's a little example of me showing that `MeshData` is hidden, but is properly updated/managed when I remove Texts, as well as `Computed Buffer Size` being non-editable. Everything is editable if the user switches to *Debug* inspector mode.

https://github.com/user-attachments/assets/44b9e36d-1a4b-4913-921c-ef06fcaf5452

# The Future
I want to add a button and some context menus to grab all relevant components + sanitize current state (remove null/duplicate texts/modifiers), but that will be later.

