### PR TITLE
added hydration logic to oneanble

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -59,8 +59,6 @@ namespace TextTween.Editor
                     _manager.Add(o);
                 }
                 tweenManager.Apply();
-                // Force buffer re-computation, when Remove() is called, Texts appears to be using previous Texts state.
-                tweenManager.TryUpdateComputedBufferSize();
                 HydrateCurrentState();
             }
         }

--- a/Runtime/Modifiers/WarpModifier.cs
+++ b/Runtime/Modifiers/WarpModifier.cs
@@ -77,7 +77,7 @@ namespace TextTween.Modifiers
                 CharData characterData = _data[index];
                 float width = characterData.TextBounds.Max.x - characterData.TextBounds.Min.x;
 
-                if (!characterData.IsValid() || width == 0)
+                if (!characterData.IsValid() || width < 1)
                 {
                     return;
                 }

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -69,18 +69,27 @@ namespace TextTween
                 
                 To avoid this, force-update the meshes to ensure we're in a known-good state.
              */
-            foreach (TMP_Text text in Texts)
-            {
-                if (text != null)
-                {
-                    text.ForceMeshUpdate(ignoreActiveState: true);
-                }
-            }
-
+            int capacity = CalculateCapacity();
+            TryUpdateComputedBufferSize(capacity);
+            
             int bufferSize = Math.Max(ExplicitBufferSize, ComputedBufferSize);
             bufferSize = Math.Max(0, bufferSize);
             Original = new MeshArray(bufferSize, Allocator.Persistent);
             Modified = new MeshArray(bufferSize, Allocator.Persistent);
+            
+            Original.EnsureCapacity(capacity);
+            Modified.EnsureCapacity(capacity);
+            
+            foreach (MeshData meshData in MeshData)
+            {
+                if (meshData.Text != null)
+                {
+                    meshData.Text.ForceMeshUpdate(ignoreActiveState: true);
+                    meshData.Update(Original, meshData.Offset);
+                }
+            }
+
+            Apply();
 
             TMPro_EventManager.TEXT_CHANGED_EVENT.Remove(_onTextChange);
             TMPro_EventManager.TEXT_CHANGED_EVENT.Add(_onTextChange);


### PR DESCRIPTION
### Overview
When we disable a `TextTweenManager` we dispose all native arrays and during `OnEnable` we recreate them but not hydrate the `Original` this action results in working on a non initialized data. This problem is hidden on Unity 6 since TMP does actually call `TEXT_CHANGE_EVENT` but not on 2022 hence the magic of disappearing texts.

There seems to be another problem where TMP allocates additional vertices thus ending up in an exception throw while copying from mesh itself.

Fixes #51 