### PR TITLE
Pretty Editor (v2)

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -93,8 +93,16 @@ namespace TextTween.Editor
             }
             using (new HorizontalLayoutGroup(this))
             {
-                CheckAndRemoveDuplicates(tweenManager.Texts, "Remove Duplicate Texts");
-                CheckAndRemoveDuplicates(tweenManager.Modifiers, "Remove Duplicate Modifiers");
+                CheckAndRemoveDuplicates(
+                    tweenManager.Texts,
+                    _currentTextDuplicateBuffer,
+                    "Remove Duplicate Texts"
+                );
+                CheckAndRemoveDuplicates(
+                    tweenManager.Modifiers,
+                    _currentModifiersDuplicateBuffer,
+                    "Remove Duplicate Modifiers"
+                );
             }
         }
 
@@ -121,13 +129,23 @@ namespace TextTween.Editor
             }
         }
 
-        private void CheckAndRemoveDuplicates<T>(List<T> list, string buttonText)
+        private void CheckAndRemoveDuplicates<T>(
+            List<T> list,
+            HashSet<T> duplicateBuffer,
+            string buttonText
+        )
             where T : Object
         {
-            if (list.Distinct().Count() == list.Count)
+            duplicateBuffer.Clear();
+            foreach (T element in list)
+            {
+                duplicateBuffer.Add(element);
+            }
+            if (duplicateBuffer.Count == list.Count)
             {
                 return;
             }
+
             if (GUILayout.Button(buttonText, _impactButtonStyle))
             {
                 Dictionary<T, int> elementCounts = new();

--- a/Editor/Utilities.meta
+++ b/Editor/Utilities.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9310a997055847aaaf9b7e13cfa8ea55
+timeCreated: 1746199121

--- a/Editor/Utilities/HorizontalLayoutGroup.cs
+++ b/Editor/Utilities/HorizontalLayoutGroup.cs
@@ -1,0 +1,22 @@
+﻿namespace TextTween.Editor.Utilities
+{
+#if UNITY_EDITOR
+    using System;
+    using UnityEditor;
+
+    // Simple auto-closing Horizontal layout group
+    internal readonly struct HorizontalLayoutGroup : IDisposable
+    {
+        // Can't have parameter-less struct constructors, so introduce a useless parameter
+        public HorizontalLayoutGroup(object uselessParameter)
+        {
+            EditorGUILayout.BeginHorizontal();
+        }
+
+        public void Dispose()
+        {
+            EditorGUILayout.EndHorizontal();
+        }
+    }
+#endif
+}

--- a/Editor/Utilities/HorizontalLayoutGroup.cs.meta
+++ b/Editor/Utilities/HorizontalLayoutGroup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 412a33be2bc34e7d84781ecf62de2640
+timeCreated: 1746199144


### PR DESCRIPTION
# Overview
When working with assets like this that require some amount of configuration, I really like having custom inspectors that make it really easy to configure the thing correctly. The previous (now missing) approach of context menus is ok, but there's a discoverability problem - how do you let the developer/user know that there is a context menu that does useful stuff in the first place?

# The Fix
Smart buttons! Three different kinds.

1. Null component checks. If you have null stuff, there will now be a big yellow button that you can click to remove the null stuff (safely). This button is not rendered if you do not have null stuff.
2. Duplicate component checks. If you have duplicate components serialized, there will now be a big yellow button that you can click to remove the duplicate stuff (safely). Duplicate removal is done end-first. This button is not rendered if you do not have duplicate stuff.
3. Sync checks. If your object has extra modifiers or texts that the `TextTweenManager` does not know about, this is *likely* a bug, but not necessarily. So instead of a yellow button, we have a normal button that will sync your state for you. This button is not rendered if the TextTweenManager's heirarchy matches its serialized state.

# Note
This approach generates *some* garbage on GUI rendering due to simplicity of LINQ code. I could optimize this with some more caches/buffers if you don't want the extra garbage generated. 

# Preview

https://github.com/user-attachments/assets/cef85c45-7197-4c61-a570-8f65aa05f364

