### PR TITLE
Bug Fix: Ensure Deleted Texts are Cleaned Up

### DIFF
--- a/Editor/TextDataManagerInspector.cs
+++ b/Editor/TextDataManagerInspector.cs
@@ -65,10 +65,6 @@ namespace TextTween.Editor
 
                 foreach (TMP_Text o in remove)
                 {
-                    if (o == null)
-                    {
-                        continue;
-                    }
                     _manager.Remove(o);
                 }
                 foreach (TMP_Text o in add)


### PR DESCRIPTION
# Overview
There is currently a bug where, if you remove a deleted TMP instance from TextTweenManager, the internal MeshData/state is not cleaned up, causing lingering artifacts.

# The (Partial) Fix
Simply remove the null check in the Editor code. It is safe and correct to remove all deltas, even if they are null. We should only be gating *addition* of null Texts.

# Steps to Reproduce
- Have a TextTweenManager managing a valid text
- Delete the text
- Remove the text from the `Texts` list

Expectation: 
- MeshData for that text is cleaned up

Reality:
- MeshData for that text is not cleaned up

Before fix:

https://github.com/user-attachments/assets/7c81d202-56aa-474d-9b82-963405fd5246

After fix:

https://github.com/user-attachments/assets/ba617c7d-6c4c-49c0-8365-68d50785ca2b

# Remaining Work
The computed buffer size is not updated appropriately upon text removal, but we can handle that as a separate issue.