### PR TITLE
Bug Fix: Empty Text Handling

### DIFF
--- a/Runtime/Extensions/TextMeshProExtensions.cs
+++ b/Runtime/Extensions/TextMeshProExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace TextTween.Extensions
 {
+    using System;
     using TMPro;
     using UnityEngine;
     using Utilities;
@@ -60,11 +61,7 @@
                 }
 
                 array = new T[vertexCount];
-                for (int i = 0; i < vertexCount; i++)
-                {
-                    array[i] = value;
-                }
-
+                Array.Fill(array, value);
                 wasModified = true;
                 return array;
             }

--- a/Runtime/Extensions/TextMeshProExtensions.cs
+++ b/Runtime/Extensions/TextMeshProExtensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace TextTween.Extensions
 {
-    using System.Linq;
     using TMPro;
     using UnityEngine;
     using Utilities;
@@ -35,38 +34,17 @@
                 return;
             }
 
-            TMP_MeshInfo meshInfo = tmp.textInfo.meshInfo[0];
-
-            int vertexCount = tmp.GetVertexCount();
             bool wasModified = false;
-
-            Color[] colors = mesh.colors;
-            PopulateArrayIfNeeded(ref colors, tmp.color);
-            mesh.colors = colors;
-
-            Color32[] colors32 = mesh.colors32;
-            PopulateArrayIfNeeded(ref colors32, tmp.color);
-            mesh.colors32 = colors32;
-
-            Vector2[] uv = mesh.uv;
-            PopulateArrayIfNeeded(ref uv, Vector2.zero);
-            mesh.uv = uv;
-
-            Vector2[] uv2 = mesh.uv2;
-            PopulateArrayIfNeeded(ref uv2, Vector2.zero);
-            mesh.uv2 = uv2;
-
+            int vertexCount = tmp.GetVertexCount();
+            mesh.colors = PopulateArrayIfNeeded(mesh.colors, tmp.color);
+            mesh.colors32 = PopulateArrayIfNeeded(mesh.colors32, tmp.color);
+            mesh.uv = PopulateArrayIfNeeded(mesh.uv, Vector2.zero);
+            mesh.uv2 = PopulateArrayIfNeeded(mesh.uv2, Vector2.zero);
             if (!wasModified)
             {
                 return;
             }
 
-            meshInfo.colors32 = colors32.ToArray();
-            meshInfo.vertices = mesh.vertices.ToArray();
-            meshInfo.uvs0 = uv.ToArray();
-            meshInfo.uvs2 = uv2.ToArray();
-            tmp.textInfo.meshInfo[0] = meshInfo;
-            tmp.UpdateGeometry(mesh, 0);
             if (tmp is TextMeshProUGUI textMeshProUGUI && textMeshProUGUI.canvasRenderer != null)
             {
                 textMeshProUGUI.canvasRenderer.SetMesh(tmp.mesh);
@@ -74,11 +52,11 @@
 
             return;
 
-            void PopulateArrayIfNeeded<T>(ref T[] array, T value)
+            T[] PopulateArrayIfNeeded<T>(T[] array, T value)
             {
                 if (array?.Length == vertexCount)
                 {
-                    return;
+                    return array;
                 }
 
                 array = new T[vertexCount];
@@ -88,6 +66,7 @@
                 }
 
                 wasModified = true;
+                return array;
             }
         }
     }

--- a/Runtime/Extensions/TextMeshProExtensions.cs
+++ b/Runtime/Extensions/TextMeshProExtensions.cs
@@ -1,0 +1,94 @@
+﻿namespace TextTween.Extensions
+{
+    using System.Linq;
+    using TMPro;
+    using UnityEngine;
+    using Utilities;
+
+    public static class TextMeshProExtensions
+    {
+        public static void EnsureArrayIntegrity(this TMP_Text tmp, bool forceMeshUpdate = true)
+        {
+            if (tmp == null)
+            {
+                return;
+            }
+
+            if (forceMeshUpdate)
+            {
+                tmp.ForceMeshUpdate(true);
+            }
+
+            if (tmp.mesh == null)
+            {
+                return;
+            }
+
+            if (tmp.textInfo.meshInfo is not { Length: > 0 })
+            {
+                return;
+            }
+
+            Mesh mesh = tmp.mesh;
+            if (mesh.vertices is not { Length: > 0 })
+            {
+                return;
+            }
+
+            TMP_MeshInfo meshInfo = tmp.textInfo.meshInfo[0];
+
+            int vertexCount = tmp.GetVertexCount();
+            bool wasModified = false;
+
+            Color[] colors = mesh.colors;
+            PopulateArrayIfNeeded(ref colors, tmp.color);
+            mesh.colors = colors;
+
+            Color32[] colors32 = mesh.colors32;
+            PopulateArrayIfNeeded(ref colors32, tmp.color);
+            mesh.colors32 = colors32;
+
+            Vector2[] uv = mesh.uv;
+            PopulateArrayIfNeeded(ref uv, Vector2.zero);
+            mesh.uv = uv;
+
+            Vector2[] uv2 = mesh.uv2;
+            PopulateArrayIfNeeded(ref uv2, Vector2.zero);
+            mesh.uv2 = uv2;
+
+            if (!wasModified)
+            {
+                return;
+            }
+
+            meshInfo.colors32 = colors32.ToArray();
+            meshInfo.vertices = mesh.vertices.ToArray();
+            meshInfo.uvs0 = uv.ToArray();
+            meshInfo.uvs2 = uv2.ToArray();
+            tmp.textInfo.meshInfo[0] = meshInfo;
+            tmp.UpdateGeometry(mesh, 0);
+            if (tmp is TextMeshProUGUI textMeshProUGUI && textMeshProUGUI.canvasRenderer != null)
+            {
+                textMeshProUGUI.canvasRenderer.SetMesh(tmp.mesh);
+            }
+
+            return;
+
+            void PopulateArrayIfNeeded<T>(ref T[] array, T value)
+            {
+                if (array?.Length == vertexCount)
+                {
+                    return;
+                }
+
+                array = new T[vertexCount];
+                for (int i = 0; i < vertexCount; i++)
+                {
+                    array[i] = value;
+                }
+
+                wasModified = true;
+            }
+        }
+    }
+}

--- a/Runtime/Extensions/TextMeshProExtensions.cs
+++ b/Runtime/Extensions/TextMeshProExtensions.cs
@@ -36,6 +36,12 @@
             }
 
             bool wasModified = false;
+            /*
+                There is a strange issue in Unity 2022 where, for an initial, empty text,
+                vertex count = 4, mesh.vertices length will be 4, but the color and uv array
+                lengths will be 0. This causes a null reference exception when trying to
+                perform our internal operations, so let's "fix" the state if this is the case.
+             */
             int vertexCount = tmp.GetVertexCount();
             mesh.colors = PopulateArrayIfNeeded(mesh.colors, tmp.color);
             mesh.colors32 = PopulateArrayIfNeeded(mesh.colors32, tmp.color);

--- a/Runtime/Extensions/TextMeshProExtensions.cs.meta
+++ b/Runtime/Extensions/TextMeshProExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1dfaf660b84b45c1b3e901d4ea189503
+timeCreated: 1746568129

--- a/Runtime/MeshArray.cs
+++ b/Runtime/MeshArray.cs
@@ -2,7 +2,6 @@ namespace TextTween
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using TMPro;
     using Unity.Collections;
     using Unity.Jobs;

--- a/Runtime/MeshArray.cs
+++ b/Runtime/MeshArray.cs
@@ -2,10 +2,12 @@ namespace TextTween
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using TMPro;
     using Unity.Collections;
     using Unity.Jobs;
     using Unity.Mathematics;
+    using UnityEngine;
     using Utilities;
 
     public class MeshArray : IDisposable
@@ -82,27 +84,31 @@ namespace TextTween
             _uvs2.CopyFrom(source._uvs2);
         }
 
-        public void CopyFrom(TMP_Text text, int length, int offset)
+        public void CopyFrom(TMP_Text text, int offset, int length)
         {
-            text.mesh.vertices.MemCpy(_vertices, offset, length);
-            text.mesh.colors.MemCpy(_colors, offset, length);
-            text.mesh.uv.MemCpy(_uvs0, offset, length);
-            text.mesh.uv2.MemCpy(_uvs2, offset, length);
+            Mesh mesh = text.mesh;
+            mesh.vertices.MemCpy(_vertices, offset, length);
+            mesh.colors.MemCpy(_colors, offset, length);
+            mesh.uv.MemCpy(_uvs0, offset, length);
+            mesh.uv2.MemCpy(_uvs2, offset, length);
             CreateCharData(text, offset, length);
         }
 
         public void CopyTo(TMP_Text text, int offset, int length)
         {
-            text.mesh.SetVertices(_vertices, offset, length);
-            text.mesh.SetColors(_colors, offset, length);
-            text.mesh.SetUVs(0, _uvs0, offset, length);
-            text.mesh.SetUVs(1, _uvs2, offset, length);
+            Mesh mesh = text.mesh;
+            mesh.SetVertices(_vertices, offset, length);
+            mesh.SetColors(_colors, offset, length);
+            mesh.SetUVs(0, _uvs0, offset, length);
+            mesh.SetUVs(1, _uvs2, offset, length);
 
             TMP_MeshInfo[] meshInfos = text.textInfo.meshInfo;
             for (int j = 0; j < meshInfos.Length; j++)
             {
-                meshInfos[j].colors32 = text.mesh.colors32;
-                meshInfos[j].vertices = text.mesh.vertices;
+                TMP_MeshInfo meshInfo = meshInfos[j];
+                meshInfo.colors32 = mesh.colors32;
+                meshInfo.vertices = mesh.vertices;
+                meshInfos[j] = meshInfo;
             }
 
             text.UpdateVertexData(TMP_VertexDataUpdateFlags.All);
@@ -112,7 +118,7 @@ namespace TextTween
         {
             const int vertexPerChar = 4;
             TMP_CharacterInfo[] characterInfos = text.textInfo.characterInfo;
-            int charLength = characterInfos.Length;
+            int charLength = text.textInfo.characterCount;
             MinMaxAABB textBounds = new(text.textBounds.min, text.textBounds.max);
             for (int i = 0, ci = 0; i < length && ci < charLength; i++, ci = i / vertexPerChar)
             {

--- a/Runtime/MeshData.cs
+++ b/Runtime/MeshData.cs
@@ -21,7 +21,7 @@ namespace TextTween
 
         public void Apply(MeshArray array)
         {
-            if (Text == null || Text.mesh == null || Text.text.Length == 0)
+            if (Text == null || Text.mesh == null || Text.text == null || Text.text.Length == 0)
             {
                 return;
             }
@@ -29,10 +29,14 @@ namespace TextTween
             array.CopyTo(Text, Offset, Length);
         }
 
-        public void Update(MeshArray meshArray, int offset)
+        public void Update(MeshArray meshArray, int offset, bool copyFrom = true)
         {
             int length = Text.GetVertexCount();
-            meshArray.CopyFrom(Text, length, offset);
+            if (copyFrom)
+            {
+                meshArray.CopyFrom(Text, offset, length);
+            }
+
             Offset = offset;
             Length = length;
         }

--- a/Runtime/MeshData.cs
+++ b/Runtime/MeshData.cs
@@ -21,7 +21,7 @@ namespace TextTween
 
         public void Apply(MeshArray array)
         {
-            if (Text == null || Text.mesh == null || Text.text == null || Text.text.Length == 0)
+            if (Text == null || Text.mesh == null || string.IsNullOrEmpty(Text.text))
             {
                 return;
             }

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -81,7 +81,7 @@ namespace TextTween
             }
 
             Allocate();
-            CheckForMeshChanges(allTexts: true);
+            CheckForMeshChanges();
             Apply();
 
             TMPro_EventManager.TEXT_CHANGED_EVENT.Remove(_onTextChange);
@@ -98,8 +98,8 @@ namespace TextTween
         {
             foreach (TMP_Text text in Texts)
             {
-                RemoveAgent(text);
                 text.EnsureArrayIntegrity();
+                RemoveAgent(text);
             }
         }
 
@@ -119,10 +119,9 @@ namespace TextTween
             {
                 return;
             }
-            
-            AddAgent(tmp);
 
             tmp.EnsureArrayIntegrity();
+            AddAgent(tmp);
             Allocate();
 
             MeshData last = TextTween.MeshData.Empty;
@@ -151,7 +150,7 @@ namespace TextTween
             {
                 RemoveAgent(tmp);
             }
-            
+
             Texts.Remove(tmp);
             meshData.Apply(Original);
             MeshData.Remove(meshData);
@@ -173,12 +172,11 @@ namespace TextTween
             }
 
             Allocate();
-            OnChangeArguments[0] = obj as TMP_Text;
-            CheckForMeshChanges(allTexts: false, OnChangeArguments);
+            CheckForMeshChanges(obj as TMP_Text);
             Apply();
         }
 
-        internal void CheckForMeshChanges(bool allTexts, params TMP_Text[] textsToUpdate)
+        internal void CheckForMeshChanges(TMP_Text textToUpdate = null)
         {
             for (int i = 0; i < MeshData.Count; i++)
             {
@@ -198,7 +196,7 @@ namespace TextTween
                 meshData.Update(
                     Original,
                     meshData.Offset,
-                    copyFrom: allTexts || 0 <= Array.IndexOf(textsToUpdate, meshData.Text)
+                    copyFrom: textToUpdate == null || textToUpdate == meshData.Text
                 );
             }
         }
@@ -268,7 +266,7 @@ namespace TextTween
 
             return Original.Move(from, to, length, dependsOn);
         }
-        
+
         private void AddAgent(TMP_Text tmp)
         {
             if (!tmp.TryGetComponent(out TextTweenAgent agent))
@@ -280,7 +278,7 @@ namespace TextTween
 
         private static void RemoveAgent(TMP_Text tmp)
         {
-            if (tmp.TryGetComponent(out TextTweenAgent agent))
+            if (tmp != null && tmp.TryGetComponent(out TextTweenAgent agent))
             {
                 agent.Remove();
             }

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -7,7 +7,6 @@ namespace TextTween
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Extensions;
     using TMPro;
     using Unity.Collections;
@@ -23,6 +22,8 @@ namespace TextTween
     [AddComponentMenu("TextTween/Text Tween Manager")]
     public class TextTweenManager : MonoBehaviour, IDisposable
     {
+        private static readonly TMP_Text[] OnChangeArguments = new TMP_Text[1];
+
         [Header("Tween Config")]
         [Range(0, 1f)]
         public float Progress;
@@ -80,7 +81,7 @@ namespace TextTween
             }
 
             Allocate();
-            CheckForMeshChanges(MeshData.Select(meshData => meshData.Text).ToArray());
+            CheckForMeshChanges(allTexts: true);
             Apply();
 
             TMPro_EventManager.TEXT_CHANGED_EVENT.Remove(_onTextChange);
@@ -172,11 +173,12 @@ namespace TextTween
             }
 
             Allocate();
-            CheckForMeshChanges(obj as TMP_Text);
+            OnChangeArguments[0] = obj as TMP_Text;
+            CheckForMeshChanges(allTexts: false, OnChangeArguments);
             Apply();
         }
 
-        internal void CheckForMeshChanges(params TMP_Text[] textsToUpdate)
+        internal void CheckForMeshChanges(bool allTexts, params TMP_Text[] textsToUpdate)
         {
             for (int i = 0; i < MeshData.Count; i++)
             {
@@ -196,7 +198,7 @@ namespace TextTween
                 meshData.Update(
                     Original,
                     meshData.Offset,
-                    copyFrom: 0 <= Array.IndexOf(textsToUpdate, meshData.Text)
+                    copyFrom: allTexts || 0 <= Array.IndexOf(textsToUpdate, meshData.Text)
                 );
             }
         }


### PR DESCRIPTION
&check; Fixes #59 

# Overview 
Ok, this was really tricky. This is actually two fixes in 1.

Fix 1: Proper handling of empty texts
Fix 2: Properly handle *new texts being instantiated*

Let's dive into each one.

# Fix 1: Proper handling of empty texts
As mentioned in the referenced issue, when `TextMeshPro - Text` instances are created, they are in some weird, invalid state. Even forcing a mesh update doesn't initialize them properly. Their vertex count is different than their color/uv array counts.

To fix this, I've created an extension - `EnsureArrayIntegrity`. This both forces a mesh update and checks for this invalid state. If invalid state is detected, it does the best job it can to rectify the state and force updates.

With this fix, you can now add empty texts to a TextTweenManager and play around with the progress, then add text and have the progress applied! Great success!

But, while testing this, I noticed another problem - whenever you would add a new TMP instance to the scene, the state managed by the TextTweenManager would get corrupted somehow. Say I have a color modifier from red -> white managing one text, and progress was at 50% - light pink. When a new text is added, the text's color changes to some dark red, and stops being able to be tweened. The reason for this is that the OnChange delegate is triggered, and our MeshData runs "Update", which *copies current text state to our array*. This is wrong! The current text state is *not* the original text state, we need to somehow detect / prevent this. Which leads me to...

# Fix 2: Properly handle *new texts being instantiated*
Similar to some previous iterations of this code, I've augmented the change detection code to take in *context*. Every time there is a change, we need to properly calculate offset and length, no questions asked. However, only *sometimes* do we want to copy state between the text and our buffers.

To handle this, I pass in the context of what texts should have their state updated. In initialization, this is every text the tween manager is managing. In an on-change scenario, this is *only the text being changed*.

# The result
You can now add, remove, modify texts in any configuration - empty, initliaized, whatever you want, this thing now handles it without any errors and with the expected behavior.