### PR TITLE
TextTweenAgent implementation

### DIFF
--- a/Runtime/TextTweenAgent.cs
+++ b/Runtime/TextTweenAgent.cs
@@ -17,6 +17,7 @@ namespace TextTween
         
         private void OnEnable()
         {
+            hideFlags = HideFlags.HideInInspector;
             _text = GetComponent<TMP_Text>();
         }
 

--- a/Runtime/TextTweenAgent.cs
+++ b/Runtime/TextTweenAgent.cs
@@ -1,0 +1,57 @@
+namespace TextTween
+{
+    using Attributes;
+    using TMPro;
+    using UnityEngine;
+
+    [ExecuteInEditMode]
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(TMP_Text))]
+    public class TextTweenAgent : MonoBehaviour
+    {
+        [SerializeField, ReadOnly] 
+        private TextTweenManager _owner;
+
+        private TMP_Text _text;
+        private bool _marked;
+        
+        private void OnEnable()
+        {
+            _text = GetComponent<TMP_Text>();
+        }
+
+        internal void SetOwner(TextTweenManager owner)
+        {
+            if (_owner != null)
+            {
+                _owner.Remove(_text, true);
+            }
+            _owner = owner;
+        }
+
+        internal void Remove()
+        {
+            if (_marked)
+            {
+                return;
+            }
+            if (Application.isPlaying)
+            {
+                Destroy(this);
+            }
+            else
+            {
+                DestroyImmediate(this);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_owner != null && !_marked)
+            {
+                _marked = true;
+                _owner.Remove(_text);
+            }
+        }
+    }
+}

--- a/Runtime/TextTweenAgent.cs.meta
+++ b/Runtime/TextTweenAgent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 43f5fe03edec40069c239dc5997aeccf
+timeCreated: 1747075427

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -18,6 +18,7 @@ namespace TextTween
 #endif
 
     [Serializable, ExecuteInEditMode]
+    [AddComponentMenu("TextTween/Text Tween Manager")]
     public class TextTweenManager : MonoBehaviour, IDisposable
     {
         [Header("Tween Config")]
@@ -122,6 +123,8 @@ namespace TextTween
             {
                 return;
             }
+            
+            AddAgent(tmp);
 
             Allocate();
 
@@ -140,13 +143,19 @@ namespace TextTween
             Apply();
         }
 
-        public void Remove(TMP_Text text)
+        public void Remove(TMP_Text tmp, bool retainAgent = false)
         {
-            if (!MeshData.TryGetValue(text, out MeshData meshData))
+            if (!MeshData.TryGetValue(tmp, out MeshData meshData))
             {
                 return;
             }
 
+            if (!retainAgent)
+            {
+                RemoveAgent(tmp);
+            }
+            
+            Texts.Remove(tmp);
             meshData.Apply(Original);
             MeshData.Remove(meshData);
 
@@ -257,6 +266,23 @@ namespace TextTween
             }
 
             return Original.Move(from, to, length, dependsOn);
+        }
+        
+        private void AddAgent(TMP_Text tmp)
+        {
+            if (!tmp.TryGetComponent(out TextTweenAgent agent))
+            {
+                agent = tmp.gameObject.AddComponent<TextTweenAgent>();
+            }
+            agent.SetOwner(this);
+        }
+
+        private static void RemoveAgent(TMP_Text tmp)
+        {
+            if (tmp.TryGetComponent(out TextTweenAgent agent))
+            {
+                agent.Remove();
+            }
         }
 
         public void Dispose()

--- a/Runtime/TextTweenManager.cs
+++ b/Runtime/TextTweenManager.cs
@@ -104,6 +104,7 @@ namespace TextTween
                 {
                     text.ForceMeshUpdate(true);
                 }
+                RemoveAgent(text);
             }
         }
 


### PR DESCRIPTION
### Overview
This PR includes few new things and some minor changes:
* **TextTweenAgent:** A new component that we add onto TMP that `TextTweenManager` controls. This allows us to remove the text that gets deleted from TextTweenManager even in runtime and fixes another issue where If we manage a text from a `TextTweenManager` lets call this _TTM1_ and user tries to add control this text by another _TTM2_ things get complicated. This component allows us to have a single `Owner` for the TMP itself and transfer the ownership if required.
* A deleted text used to remove only the `MeshData` which left a null element in `Texts` array. Now it is getting removed from `Texts` as well.
* For sometime now I wanted to add a `AddComponentMenu` attribute to `TextTweenManger` so that it would show up under `TextTween` folder. Finally remembered to add it :)