### PR TITLE
Fix buffer move calculations

### DIFF
--- a/Runtime/Utilities/NativeArrayUtility.cs
+++ b/Runtime/Utilities/NativeArrayUtility.cs
@@ -142,7 +142,7 @@ namespace TextTween.Utilities
                 {
                     for (int i = 0; i < _length; i++)
                     {
-                        if (_to + i > _source.Length || _from + i > _source.Length)
+                        if (_to + i >= _source.Length || _from + i >= _source.Length)
                         {
                             return;
                         }
@@ -153,7 +153,7 @@ namespace TextTween.Utilities
                 {
                     for (int i = _length - 1; i >= 0; i--)
                     {
-                        if (_to + i > _source.Length || _from + i > _source.Length)
+                        if (_to + i >= _source.Length || _from + i >= _source.Length)
                         {
                             continue;
                         }

--- a/Runtime/Utilities/NativeArrayUtility.cs
+++ b/Runtime/Utilities/NativeArrayUtility.cs
@@ -142,6 +142,10 @@ namespace TextTween.Utilities
                 {
                     for (int i = 0; i < _length; i++)
                     {
+                        if (_to + i > _source.Length || _from + i > _source.Length)
+                        {
+                            return;
+                        }
                         _source[_to + i] = _source[_from + i];
                     }
                 }
@@ -149,6 +153,10 @@ namespace TextTween.Utilities
                 {
                     for (int i = _length - 1; i >= 0; i--)
                     {
+                        if (_to + i > _source.Length || _from + i > _source.Length)
+                        {
+                            continue;
+                        }
                         _source[_to + i] = _source[_from + i];
                     }
                 }


### PR DESCRIPTION
# Overview
When TextTween launches in an editor context where TMP has shrunk the buffers to minimum needed, the resize calculations are wrong, as we're trying to move a bunch of essentially junk data. 

After some testing, the below strategy appears to be correct:

- When moving, if we start moving past the end of "known good", stop.

That's pretty much it.

Now, when TMP shrinks/minimally-resizes buffers, everything appears to work with no errors.